### PR TITLE
Fix ModuleNotFoundError in Django 2.x

### DIFF
--- a/fitapp/views.py
+++ b/fitapp/views.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.signals import user_logged_in
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.dispatch import receiver
 from django.http import HttpResponse, HttpResponseServerError, Http404
 from django.shortcuts import redirect, render


### PR DESCRIPTION
Fix "ModuleNotFoundError: No module named 'django.core.urlresolvers'.

Solution found here: https://stackoverflow.com/questions/43139081/importerror-no-module-named-django-core-urlresolvers